### PR TITLE
Replaced config.py with config-fake.py in external Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY ./pages ./
 WORKDIR /usr/src/app/utils
 COPY ./utils ./
 WORKDIR /usr/src/app
-COPY app.py config.py app_sidebar_collapsible.py assets globals.py globalsUpdater.py Procfile ./
+COPY app.py config-fake.py app_sidebar_collapsible.py assets globals.py globalsUpdater.py Procfile ./
 
 WORKDIR /usr/src/app/assets
 COPY assets/style.css ./


### PR DESCRIPTION
Encountered error while building and pushing docker image as a part of the CI. 
This was occuring due to config.py mentioned in COPY command in Dockerfile not being there in the repo online. 
Added config-fake.py in its place for now, so image is pushed to Dockerhub. 

But eventually, will need to handle as per decision to consolidate differences in external and internal repos.