### PR TITLE
COPY config-fake.py as config.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY ./pages ./
 WORKDIR /usr/src/app/utils
 COPY ./utils ./
 WORKDIR /usr/src/app
-COPY app.py config-fake.py app_sidebar_collapsible.py assets globals.py globalsUpdater.py Procfile ./
+COPY config-fake.py ./config.py
+COPY app.py app_sidebar_collapsible.py assets globals.py globalsUpdater.py Procfile ./
 
 WORKDIR /usr/src/app/assets
 COPY assets/style.css ./


### PR DESCRIPTION
In the external public Docker image, make the config-fake.py available as config.py by copying it over into the container as config.py

Internally, if custom config.py is needed, can copy it over in the internal Dockerfile.

But might not even need the config.py since credentials can be stored as ENVIRONMENT variables.
Refer to [this issue](https://github.com/e-mission/e-mission-docs/issues/1048).