### PR TITLE
Removed expose port duplication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ COPY data ./
 
 # open listening port, this may be overridden in docker-compose file
 EXPOSE ${SERVER_PORT}
-EXPOSE ${DASH_SERVER_PORT}
 
 # run the dashboard
 WORKDIR /usr/src/app/dashboard_setup


### PR DESCRIPTION
Found usage of two variables referring to same port. Had exposed using both variable names.
But since same port exposed, should be fine to expose just once.